### PR TITLE
Interface cleanup (#12)

### DIFF
--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/FrameState.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/FrameState.cs
@@ -11,22 +11,25 @@ namespace ColinCWilliams.CSharpNavigationService
     /// <summary>
     /// Represents the saved state for a frame.
     /// </summary>
-    public class FrameState
+    [DataContract]
+    internal class FrameState
     {
         /// <summary>
         /// Gets or sets the Navigation state for a frame.
         /// </summary>
+        [DataMember]
         public string Navigation { get; set; }
 
         /// <summary>
         /// Gets or sets the Navigation Context Service state for a frame.
         /// </summary>
+        [DataMember]
         public NavigationContextServiceState ContextService { get; set; }
 
         /// <summary>
         /// Gets or sets the states for the individual pages this Navigation Service has seen.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Setter needed for serialization.")]
-        public IDictionary<string, PageState> PageStates { get; set; }
+        [DataMember]
+        public Dictionary<string, PageState> PageStates { get; set; }
     }
 }

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/INavigationContextService.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/INavigationContextService.cs
@@ -9,7 +9,7 @@ namespace ColinCWilliams.CSharpNavigationService
     /// A service to manage NavigationContexts during navigation. Stores them
     /// with a related ID so that they may be retrieved later.
     /// </summary>
-    public interface INavigationContextService
+    internal interface INavigationContextService
     {
         /// <summary>
         ///  Adds a context to the context store.

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/INavigationService.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/INavigationService.cs
@@ -6,23 +6,12 @@
 namespace ColinCWilliams.CSharpNavigationService
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// The interface for a NavigationService that supports passing complex types.
     /// </summary>
     public interface INavigationService
     {
-        /// <summary>
-        /// Gets the context service associated with this NavigationService.
-        /// </summary>
-        INavigationContextService ContextService { get; }
-
-        /// <summary>
-        /// Gets the states for the individual pages this Navigation Service has seen.
-        /// </summary>
-        IDictionary<string, PageState> PageStates { get; }
-
         /// <summary>
         /// Gets a value indicating whether calling <see cref="GoBack" /> will success.
         /// </summary>

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/ISuspensionManager.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/ISuspensionManager.cs
@@ -14,7 +14,7 @@ namespace ColinCWilliams.CSharpNavigationService
     /// <summary>
     /// An interface for managing app suspension and restoration.
     /// </summary>
-    public interface ISuspensionManager
+    internal interface ISuspensionManager
     {
         /// <summary>
         /// Gets a List of custom types provided to the <see cref="DataContractSerializer"/> when

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationContextServiceState.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationContextServiceState.cs
@@ -5,14 +5,13 @@
 
 namespace ColinCWilliams.CSharpNavigationService
 {
-    using System.Collections.Generic;
     using System.Runtime.Serialization;
 
     /// <summary>
     /// The state of a NavigationContextService for saving or restoring.
     /// </summary>
     [DataContract]
-    public class NavigationContextServiceState
+    internal class NavigationContextServiceState
     {
         /// <summary>
         /// Gets or sets the ID that should be used for the next item being stored.

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationContextStore.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationContextStore.cs
@@ -10,7 +10,7 @@ namespace ColinCWilliams.CSharpNavigationService
     /// <summary>
     /// A storage location for navigation contexts.
     /// </summary>
-    public class NavigationContextStore : Dictionary<long, NavigationContextBase>
+    internal class NavigationContextStore : Dictionary<long, NavigationContextBase>
     {
     }
 }

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationService.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/NavigationService.cs
@@ -24,7 +24,12 @@ namespace ColinCWilliams.CSharpNavigationService
         private readonly WeakReference<Frame> rootFrame;
         private readonly string name;
 
-        private NavigationService(Frame frame, INavigationContextService contextService)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NavigationService"/> class.
+        /// </summary>
+        /// <param name="frame">The Frame to use for navigation.</param>
+        /// <param name="contextService">The context service to use for storing and retrieving Navigation Contexts during navigation.</param>
+        internal NavigationService(Frame frame, INavigationContextService contextService)
         {
             if (frame == null)
             {
@@ -33,7 +38,7 @@ namespace ColinCWilliams.CSharpNavigationService
 
             if (contextService == null)
             {
-                throw new ArgumentNullException(nameof(frame));
+                throw new ArgumentNullException(nameof(contextService));
             }
 
             this.contextService = contextService;
@@ -41,19 +46,6 @@ namespace ColinCWilliams.CSharpNavigationService
             this.name = frame.Name;
             this.PageStates = new Dictionary<string, PageState>();
         }
-
-        /// <summary>
-        /// Gets the context service associated with this NavigationService.
-        /// </summary>
-        public INavigationContextService ContextService
-        {
-            get { return this.contextService; }
-        }
-
-        /// <summary>
-        /// Gets the states for the individual pages this Navigation Service has seen.
-        /// </summary>
-        public IDictionary<string, PageState> PageStates { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether calling <see cref="GoBack" /> will success.
@@ -66,6 +58,19 @@ namespace ColinCWilliams.CSharpNavigationService
         /// </summary>
         /// <returns>True if forward navigation can occur, false otherwise.</returns>
         public bool CanGoForward => this.RootFrame.CanGoForward;
+
+        /// <summary>
+        /// Gets the states for the individual pages this Navigation Service has seen.
+        /// </summary>
+        internal Dictionary<string, PageState> PageStates { get; private set; }
+
+        /// <summary>
+        /// Gets the context service associated with this NavigationService.
+        /// </summary>
+        internal INavigationContextService ContextService
+        {
+            get { return this.contextService; }
+        }
 
         /// <summary>
         /// Gets the root frame for the navigation service.
@@ -114,12 +119,12 @@ namespace ColinCWilliams.CSharpNavigationService
         {
             if (frame == null)
             {
-                throw new ArgumentNullException("frame");
+                throw new ArgumentNullException(nameof(frame));
             }
 
             if (defaultPage == null)
             {
-                throw new ArgumentNullException("defaultPage");
+                throw new ArgumentNullException(nameof(defaultPage));
             }
 
             if (GetNavigationService(frame) != null)
@@ -160,7 +165,7 @@ namespace ColinCWilliams.CSharpNavigationService
         {
             if (frame == null)
             {
-                throw new ArgumentNullException("frame");
+                throw new ArgumentNullException(nameof(frame));
             }
 
             RemoveFrame(frame);
@@ -175,7 +180,7 @@ namespace ColinCWilliams.CSharpNavigationService
         {
             if (frame == null)
             {
-                throw new ArgumentNullException("frame");
+                throw new ArgumentNullException(nameof(frame));
             }
 
             return NavigationServices.FirstOrDefault(x => x.RootFrame == frame);
@@ -229,7 +234,7 @@ namespace ColinCWilliams.CSharpNavigationService
         {
             if (pageType == null)
             {
-                throw new ArgumentNullException("pageType");
+                throw new ArgumentNullException(nameof(pageType));
             }
 
             if (context != null && !SuspensionManager.KnownTypes.Contains(context.GetType()))
@@ -318,6 +323,10 @@ namespace ColinCWilliams.CSharpNavigationService
             }
         }
 
+        /// <summary>
+        /// Attempts to get the Frame from the weak reference.
+        /// </summary>
+        /// <returns>The frame or null if the Frame was garbage collected.</returns>
         private Frame GetFrameSafe()
         {
             Frame frame = null;

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/PageBase.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/PageBase.cs
@@ -23,7 +23,7 @@ namespace ColinCWilliams.CSharpNavigationService
         private static NavigationCacheMode defaultCacheMode = NavigationCacheMode.Enabled;
 
         private INavigationContextService contextService;
-        private INavigationService navigationService;
+        private NavigationService navigationService;
         private string pageKey;
 
         /// <summary>
@@ -45,6 +45,11 @@ namespace ColinCWilliams.CSharpNavigationService
             get { return defaultCacheMode; }
             set { defaultCacheMode = value; }
         }
+
+        /// <summary>
+        /// Gets the navigation service for this page.
+        /// </summary>
+        protected INavigationService LocalNavigationService => this.navigationService;
 
         /// <summary>
         /// Gets the current ViewModel for the page.
@@ -73,7 +78,7 @@ namespace ColinCWilliams.CSharpNavigationService
             // Get NavigationService
             if (this.navigationService == null)
             {
-                this.navigationService = NavigationService.GetNavigationService(this.Frame);
+                this.navigationService = NavigationService.GetNavigationService(this.Frame) as NavigationService;
                 if (this.navigationService == null)
                 {
                     throw new InvalidOperationException("Frame not registered before page navigation.");

--- a/CSharp-Navigation-Service/CSharp-Navigation-Service/PageState.cs
+++ b/CSharp-Navigation-Service/CSharp-Navigation-Service/PageState.cs
@@ -6,12 +6,11 @@
 namespace ColinCWilliams.CSharpNavigationService
 {
     using System.Collections.Generic;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// Stores state information for a specific page.
     /// </summary>
-    public class PageState : Dictionary<string, object>
+    internal class PageState : Dictionary<string, object>
     {
     }
 }

--- a/CSharp-Navigation-Service/SampleMultipleFrames/App.xaml.cs
+++ b/CSharp-Navigation-Service/SampleMultipleFrames/App.xaml.cs
@@ -102,6 +102,8 @@ namespace SampleMultipleFrames
                     Name = "RootFrame"
                 };
 
+                rootFrame.NavigationFailed += this.OnNavigationFailed;
+
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 {
                     /*********************************************************
@@ -124,8 +126,6 @@ namespace SampleMultipleFrames
 
                 // Create the NavigationService for the frame
                 App.AppNavigationService = NavigationService.RegisterFrame(rootFrame, typeof(Container));
-
-                rootFrame.NavigationFailed += this.OnNavigationFailed;
 
                 // Place the frame in the current Window
                 Window.Current.Content = rootFrame;


### PR DESCRIPTION
- Cleaned up external interfaces and classes, signifigantly reducing how much of the library is exposed externally.
- Updated ArgumentNullExceptions to use nameof instead of hard-coded string for the parameter name.
